### PR TITLE
fix(library): print wrong value when logging hidden api policy

### DIFF
--- a/library/src/main/cpp/art.cpp
+++ b/library/src/main/cpp/art.cpp
@@ -90,15 +90,13 @@ int unseal(JNIEnv *env, jint targetSdkVersion) {
 
     // TODO validate
 
-    EnforcementPolicy policy = partialRuntime->hidden_api_policy_;
-
     LOGV("is_java_debuggable: %d, is_native_debuggable: %d, safe_mode: %d", is_java_debuggable, is_native_debuggable, safe_mode);
-    LOGV("hidden api policy before : %d", policy);
+    LOGV("hidden api policy before : %d", partialRuntime->hidden_api_policy_);
     LOGV("fingerprint: %s", partialRuntime->fingerprint_.c_str());
 
     partialRuntime->hidden_api_policy_ = EnforcementPolicy::kNoChecks;
 
-    LOGV("hidden api policy after: %d", policy);
+    LOGV("hidden api policy after: %d", partialRuntime->hidden_api_policy_);
     return 0;
 }
 


### PR DESCRIPTION
Log中的`hidden api policy`打印的不对。

Test Plan:
运行Sample，日志中的hidden api policy被修改为 `EnforcementPolicy::kNoChecks`
```java
hidden api policy before : 2
06-12 00:49:46.829 13394-13394/me.weishu.freereflection.app I/FreeReflect: hidden api policy after: 0
```